### PR TITLE
Expdiente_spider: Don't use interpolation for SQL Query

### DIFF
--- a/pdl_scraper/pdl_scraper/spiders/expediente_spider.py
+++ b/pdl_scraper/pdl_scraper/spiders/expediente_spider.py
@@ -24,8 +24,7 @@ class ExpedienteSpider(scrapy.Spider):
         append = start_urls.append
 
         # get list of proyects ids from pdl_proyecto table with no events
-        query = "select expediente from pdl_proyecto WHERE legislatura={}".format(settings.LEGISLATURE)
-        res = db.query(query)
+        res = db.query("select expediente from pdl_proyecto WHERE legislatura=:legislatura", legislatura=settings.LEGISLATURE)
         for i in res:
             append(i['expediente'])
         return start_urls


### PR DESCRIPTION
Oi,

Interpolar cadenas para armar SQL Statements vulnerable a [SQL Injection](https://www.owasp.org/index.php/Testing_for_SQL_Injection_%28OTG-INPVAL-005%29#Example_1_.28classical_SQL_Injection.29:). Con el código como esta, si alguien logra modificar el environment variable del servidor dónde esta hosteado el Scrapper puede borrar toda la base o modificarla como quisiera.

Para evitar ser vulnerable, debes componer los queries en el lado de la base de datos, usando prepared statements. No conozco muy bien dataset (con psycopg2 es al toque), según @marsam esto haría que dataset use prepared statements. (Aunque tambien recomienda no usar dataset, sino SQLAlchemy directamente) 

No he buscado más casos de SQL Injection, sería bueno que veas dónde estas interpolando cadenas de lado de Python para componer SQL statements y lo modifiques.

mis 2c
